### PR TITLE
Added Movie Management module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,8 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<optional>true</optional>
+			<version>1.18.30</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -77,6 +78,16 @@
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.2.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<scope>provided</scope>
 		</dependency>
 	</dependencies>
 	<dependencyManagement>

--- a/src/main/java/com/movie/reservation/config/SwaggerConfig.java
+++ b/src/main/java/com/movie/reservation/config/SwaggerConfig.java
@@ -1,0 +1,16 @@
+package com.movie.reservation.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info().title("Movie Reservation API").version("1.0.0")
+                        .description("API documentation for the Movie Reservation System"));
+    }
+}

--- a/src/main/java/com/movie/reservation/controller/GenreController.java
+++ b/src/main/java/com/movie/reservation/controller/GenreController.java
@@ -1,0 +1,37 @@
+package com.movie.reservation.controller;
+
+import com.movie.reservation.entity.Genre;
+import com.movie.reservation.service.GenreService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/genres")
+@RequiredArgsConstructor
+@Tag(name = "Genre Management")
+public class GenreController {
+
+    private final GenreService genreService;
+
+    @PostMapping
+    public ResponseEntity<Genre> createGenre(@RequestBody Genre genre) {
+        return new ResponseEntity<>(genreService.createGenre(genre), HttpStatus.CREATED);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<Genre>> getAllGenres() {
+        return ResponseEntity.ok(genreService.getAllGenres());
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteGenre(@PathVariable UUID id) {
+        genreService.deleteGenre(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/movie/reservation/controller/MovieController.java
+++ b/src/main/java/com/movie/reservation/controller/MovieController.java
@@ -1,0 +1,50 @@
+package com.movie.reservation.controller;
+
+
+
+import com.movie.reservation.dto.MovieRequest;
+import com.movie.reservation.dto.MovieResponse;
+import com.movie.reservation.service.MovieService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/movies")
+@RequiredArgsConstructor
+public class MovieController {
+
+    private final MovieService movieService;
+
+    @PostMapping
+    public ResponseEntity<MovieResponse> addMovie(@RequestBody MovieRequest request) {
+        return new ResponseEntity<>(movieService.createMovie(request), HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<MovieResponse> updateMovie(@PathVariable UUID id, @RequestBody MovieRequest request) {
+        return ResponseEntity.ok(movieService.updateMovie(id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteMovie(@PathVariable UUID id) {
+        movieService.deleteMovie(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping
+    public ResponseEntity<List<MovieResponse>> getAllMovies() {
+        return ResponseEntity.ok(movieService.getAllMovies());
+    }
+
+    @PostMapping("/upload")
+    public ResponseEntity<String> uploadPoster(@RequestParam("file") MultipartFile file) {
+        return ResponseEntity.ok(movieService.uploadPoster(file));
+    }
+}

--- a/src/main/java/com/movie/reservation/dto/MovieRequest.java
+++ b/src/main/java/com/movie/reservation/dto/MovieRequest.java
@@ -1,0 +1,24 @@
+package com.movie.reservation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MovieRequest {
+    @Schema(description = "Title of the movie", example = "Inception")
+    private String title;
+
+    @Schema(description = "Description of the movie", example = "A mind-bending thriller")
+    private String description;
+
+    @Schema(description = "URL of the poster image", example = "/uploads/inception.jpg")
+    private String posterUrl;
+
+    @Schema(description = "UUID of the genre")
+    private UUID genreId;
+}

--- a/src/main/java/com/movie/reservation/dto/MovieResponse.java
+++ b/src/main/java/com/movie/reservation/dto/MovieResponse.java
@@ -1,0 +1,36 @@
+package com.movie.reservation.dto;
+
+import com.movie.reservation.entity.Movie;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MovieResponse {
+    @Schema(description = "UUID of the movie")
+    private UUID id;
+
+    @Schema(description = "Title of the movie")
+    private String title;
+
+    @Schema(description = "Description of the movie")
+    private String description;
+
+    @Schema(description = "URL of the poster image")
+    private String posterUrl;
+
+    @Schema(description = "Name of the genre")
+    private String genre;
+
+    public MovieResponse(Movie movie) {
+        this.id = movie.getId();
+        this.title = movie.getTitle();
+        this.description = movie.getDescription();
+        this.posterUrl = movie.getPosterUrl();
+        this.genre = movie.getGenre().getName();
+    }
+}

--- a/src/main/java/com/movie/reservation/entity/Genre.java
+++ b/src/main/java/com/movie/reservation/entity/Genre.java
@@ -1,0 +1,25 @@
+package com.movie.reservation.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.GenericGenerator;
+
+import java.util.*;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Genre {
+    @Id
+    @GeneratedValue(generator = "UUID")
+    @GenericGenerator(name = "UUID", strategy = "org.hibernate.id.UUIDGenerator")
+    @Column(name = "id", updatable = false, nullable = false)
+    private UUID id;
+
+    private String name;
+
+    @OneToMany(mappedBy = "genre", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Movie> movies = new ArrayList<>();
+}

--- a/src/main/java/com/movie/reservation/entity/Movie.java
+++ b/src/main/java/com/movie/reservation/entity/Movie.java
@@ -1,0 +1,31 @@
+package com.movie.reservation.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.GenericGenerator;
+
+import java.util.*;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Movie {
+    @Id
+    @GeneratedValue(generator = "UUID")
+    @GenericGenerator(name = "UUID", strategy = "org.hibernate.id.UUIDGenerator")
+    @Column(name = "id", updatable = false, nullable = false)
+    private UUID id;
+
+    private String title;
+    private String description;
+    private String posterUrl;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "genre_id")
+    private Genre genre;
+
+    @OneToMany(mappedBy = "movie", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Showtime> showtimes = new ArrayList<>();
+}

--- a/src/main/java/com/movie/reservation/entity/Showtime.java
+++ b/src/main/java/com/movie/reservation/entity/Showtime.java
@@ -1,0 +1,27 @@
+package com.movie.reservation.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.GenericGenerator;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Showtime {
+    @Id
+    @GeneratedValue(generator = "UUID")
+    @GenericGenerator(name = "UUID", strategy = "org.hibernate.id.UUIDGenerator")
+    @Column(name = "id", updatable = false, nullable = false)
+    private UUID id;
+
+    private LocalDateTime time;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "movie_id")
+    private Movie movie;
+}

--- a/src/main/java/com/movie/reservation/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/movie/reservation/exception/ResourceNotFoundException.java
@@ -1,0 +1,7 @@
+package com.movie.reservation.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/movie/reservation/repository/GenreRepository.java
+++ b/src/main/java/com/movie/reservation/repository/GenreRepository.java
@@ -1,0 +1,8 @@
+package com.movie.reservation.repository;
+
+import com.movie.reservation.entity.Genre;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface GenreRepository extends JpaRepository<Genre, UUID> {}

--- a/src/main/java/com/movie/reservation/repository/MovieRepository.java
+++ b/src/main/java/com/movie/reservation/repository/MovieRepository.java
@@ -1,0 +1,8 @@
+package com.movie.reservation.repository;
+
+import com.movie.reservation.entity.Movie;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface MovieRepository extends JpaRepository<Movie, UUID> {}

--- a/src/main/java/com/movie/reservation/service/FileUploadService.java
+++ b/src/main/java/com/movie/reservation/service/FileUploadService.java
@@ -1,0 +1,7 @@
+package com.movie.reservation.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface FileUploadService {
+    String uploadPoster(MultipartFile file);
+}

--- a/src/main/java/com/movie/reservation/service/GenreService.java
+++ b/src/main/java/com/movie/reservation/service/GenreService.java
@@ -1,0 +1,12 @@
+package com.movie.reservation.service;
+
+import com.movie.reservation.entity.Genre;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface GenreService {
+    Genre createGenre(Genre genre);
+    List<Genre> getAllGenres();
+    void deleteGenre(UUID id);
+}

--- a/src/main/java/com/movie/reservation/service/MovieService.java
+++ b/src/main/java/com/movie/reservation/service/MovieService.java
@@ -1,0 +1,15 @@
+package com.movie.reservation.service;
+import com.movie.reservation.dto.MovieRequest;
+import com.movie.reservation.dto.MovieResponse;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface MovieService {
+    MovieResponse createMovie(MovieRequest request);
+    MovieResponse updateMovie(UUID id, MovieRequest request);
+    void deleteMovie(UUID id);
+    List<MovieResponse> getAllMovies();
+    String uploadPoster(MultipartFile file);
+}

--- a/src/main/java/com/movie/reservation/service/impl/FileUploadServiceImpl.java
+++ b/src/main/java/com/movie/reservation/service/impl/FileUploadServiceImpl.java
@@ -1,0 +1,33 @@
+package com.movie.reservation.service.impl;
+
+import com.movie.reservation.service.FileUploadService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.UUID;
+
+@Service
+@Slf4j
+public class FileUploadServiceImpl implements FileUploadService {
+
+    private final String uploadDir = "uploads/";
+
+    @Override
+    public String uploadPoster(MultipartFile file) {
+        try {
+            String filename = UUID.randomUUID() + "_" + file.getOriginalFilename();
+            Path path = Paths.get(uploadDir + filename);
+            Files.createDirectories(path.getParent());
+            Files.write(path, file.getBytes());
+            String fileUrl = "/uploads/" + filename;
+            log.info("Poster uploaded successfully: {}", fileUrl);
+            return fileUrl;
+        } catch (IOException e) {
+            log.error("Error uploading file", e);
+            throw new RuntimeException("Failed to store file", e);
+        }
+    }
+}

--- a/src/main/java/com/movie/reservation/service/impl/GenreServiceImpl.java
+++ b/src/main/java/com/movie/reservation/service/impl/GenreServiceImpl.java
@@ -1,0 +1,42 @@
+package com.movie.reservation.service.impl;
+
+import com.movie.reservation.exception.ResourceNotFoundException;
+import com.movie.reservation.entity.Genre;
+import com.movie.reservation.repository.GenreRepository;
+import com.movie.reservation.service.GenreService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class GenreServiceImpl implements GenreService {
+
+    private final GenreRepository genreRepository;
+
+    @Override
+    public Genre createGenre(Genre genre) {
+        Genre saved = genreRepository.save(genre);
+        log.info("Genre created: {}", saved);
+        return saved;
+    }
+
+    @Override
+    public List<Genre> getAllGenres() {
+        List<Genre> genres = genreRepository.findAll();
+        log.info("Fetched {} genres", genres.size());
+        return genres;
+    }
+
+    @Override
+    public void deleteGenre(UUID id) {
+        genreRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Genre not found"));
+        genreRepository.deleteById(id);
+        log.info("Genre deleted with id: {}", id);
+    }
+}

--- a/src/main/java/com/movie/reservation/service/impl/MovieServiceImpl.java
+++ b/src/main/java/com/movie/reservation/service/impl/MovieServiceImpl.java
@@ -1,0 +1,99 @@
+package com.movie.reservation.service.impl;
+
+import com.movie.reservation.dto.MovieRequest;
+import com.movie.reservation.dto.MovieResponse;
+import com.movie.reservation.exception.ResourceNotFoundException;
+import com.movie.reservation.entity.Genre;
+import com.movie.reservation.entity.Movie;
+import com.movie.reservation.repository.GenreRepository;
+import com.movie.reservation.repository.MovieRepository;
+import com.movie.reservation.service.FileUploadService;
+import com.movie.reservation.service.MovieService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MovieServiceImpl implements MovieService {
+
+    private final MovieRepository movieRepository;
+    private final GenreRepository genreRepository;
+    private final FileUploadService fileUploadService;
+
+    @Override
+    public MovieResponse createMovie(MovieRequest request) {
+        log.info("Creating movie with title: {}", request.getTitle());
+        Genre genre = genreRepository.findById(request.getGenreId())
+                .orElseThrow(() -> {
+                    log.error("Genre not found for ID: {}", request.getGenreId());
+                    return new ResourceNotFoundException("Genre not found");
+                });
+
+        Movie movie = Movie.builder()
+                .title(request.getTitle())
+                .description(request.getDescription())
+                .posterUrl(request.getPosterUrl())
+                .genre(genre)
+                .build();
+
+        Movie saved = movieRepository.save(movie);
+        log.info("Movie created successfully: {}", saved);
+        return new MovieResponse(saved);
+    }
+
+    @Override
+    public MovieResponse updateMovie(UUID id, MovieRequest request) {
+        log.info("Updating movie with ID: {}", id);
+        Movie movie = movieRepository.findById(id)
+                .orElseThrow(() -> {
+                    log.error("Movie not found for ID: {}", id);
+                    return new ResourceNotFoundException("Movie not found");
+                });
+
+        Genre genre = genreRepository.findById(request.getGenreId())
+                .orElseThrow(() -> {
+                    log.error("Genre not found for ID: {}", request.getGenreId());
+                    return new ResourceNotFoundException("Genre not found");
+                });
+
+        movie.setTitle(request.getTitle());
+        movie.setDescription(request.getDescription());
+        movie.setPosterUrl(request.getPosterUrl());
+        movie.setGenre(genre);
+
+        Movie updated = movieRepository.save(movie);
+        log.info("Movie updated successfully: {}", updated);
+        return new MovieResponse(updated);
+    }
+
+    @Override
+    public void deleteMovie(UUID id) {
+        log.info("Deleting movie with ID: {}", id);
+        movieRepository.deleteById(id);
+        log.info("Movie deleted with ID: {}", id);
+    }
+
+    @Override
+    public List<MovieResponse> getAllMovies() {
+        List<Movie> movies = movieRepository.findAll();
+        log.info("Fetched {} movies", movies.size());
+        return movies.stream()
+                .map(MovieResponse::new)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public String uploadPoster(MultipartFile file) {
+        log.info("Uploading poster file: {}", file.getOriginalFilename());
+        String posterUrl = fileUploadService.uploadPoster(file);
+        log.info("Poster uploaded to URL: {}", posterUrl);
+        return posterUrl;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,7 +3,20 @@ spring.application.name=movie-reservation-system
 spring.datasource.url=jdbc:mysql://localhost:3306/movie_db
 spring.datasource.username=root
 spring.datasource.password=root
-
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
+spring.servlet.multipart.max-file-size=10MB
+spring.servlet.multipart.max-request-size=10MB
+
+# Swagger URL: http://localhost:8080/swagger-ui.html OR /swagger-ui/index.html
+
+# Postman Collection
+#Once the application is running, use Postman to test the following:
+#- POST /api/movies { title, description, genreId, posterUrl }
+#- GET /api/movies
+#- PUT /api/movies/{id}
+#- DELETE /api/movies/{id}
+#- POST /api/movies/upload (form-data key: file)
+#- GET /api/genres and POST /api/genres if GenreController is added
+#== Export requests from Postman as a collection for sharing or reuse


### PR DESCRIPTION
- Implemented core MovieController with CRUD operations
- Integrated GenreController to support genre creation and listing
- Enabled poster image upload via MultipartFile and local storage
- Used UUIDs for entity IDs and Lombok for boilerplate removal
- Included Swagger/OpenAPI documentation configuration
- Added DTOs for MovieRequest and MovieResponse
- Added exception handling and logging with SLF4J
- Set up application.properties with MySQL and file limits